### PR TITLE
feat: Adiciona endpoint público e view para o hall da fama e ajusta a…

### DIFF
--- a/src/main/java/com/querodoar/querodoar_api/config/SecurityConfig.java
+++ b/src/main/java/com/querodoar/querodoar_api/config/SecurityConfig.java
@@ -45,6 +45,8 @@ public class SecurityConfig {
                         //TODO: Isso aqui não está legal, verificar como liberar (acesso anônimo) com PermitAll na controller
                         .requestMatchers("/api/donation/**").permitAll()
                         .requestMatchers("/api/category/**").permitAll()
+                        //TODO: Ideia: deixar um path para cada roda publica (ex: /api/donation/public/**)
+                        .requestMatchers("/api/user/public/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/querodoar/querodoar_api/usuario/UserController.java
+++ b/src/main/java/com/querodoar/querodoar_api/usuario/UserController.java
@@ -4,6 +4,7 @@ import com.querodoar.querodoar_api.exceptions.UnauthorizedException;
 import com.querodoar.querodoar_api.usuario.dtos.UserCreateDto;
 import com.querodoar.querodoar_api.usuario.dtos.UserUpdateDto;
 import com.querodoar.querodoar_api.usuario.view.VUser;
+import com.querodoar.querodoar_api.usuario.view.VUserExperienceLastMonth;
 import com.querodoar.querodoar_api.utils.ImageProcessor;
 import com.querodoar.querodoar_api.utils.StringUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/user")
@@ -245,5 +247,15 @@ public class UserController {
             throw new UnauthorizedException("Acesso negado: apenas administradores podem acessar dados de outros usuários");
 
         return new ResponseEntity<>(user, HttpStatus.OK);
+    }
+
+    @GetMapping("/public/hall-of-fame/{top}")
+    public ResponseEntity<List<VUserExperienceLastMonth>> getHallOfFame(@PathVariable int top){
+        // TODO: Verificar valor ideal para o limit com base na página hall da fama
+        if(top <= 0 || top > 53) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+        List<VUserExperienceLastMonth> users = this.service.getTopUserExperienceLastMonth(top);
+        return ResponseEntity.ok(users);
     }
 }

--- a/src/main/java/com/querodoar/querodoar_api/usuario/UserService.java
+++ b/src/main/java/com/querodoar/querodoar_api/usuario/UserService.java
@@ -13,13 +13,16 @@ import com.querodoar.querodoar_api.usuario.dtos.UserCreateMinimalDto;
 import com.querodoar.querodoar_api.usuario.dtos.UserUpdateDto;
 import com.querodoar.querodoar_api.usuario.entity.UserToken;
 import com.querodoar.querodoar_api.usuario.repository.UserTokenRepository;
+import com.querodoar.querodoar_api.usuario.repository.VUserExperienceLastMonthService;
 import com.querodoar.querodoar_api.usuario.view.VUser;
+import com.querodoar.querodoar_api.usuario.view.VUserExperienceLastMonth;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -41,6 +44,9 @@ public class UserService {
 
     @Autowired
     private UserTokenRepository userTokenRepository;
+
+    @Autowired
+    private VUserExperienceLastMonthService vUserExperienceLastMonthService;
 
     public Page<User> getAll(Pageable pageable){
         return this.repository.findAll(pageable);
@@ -240,5 +246,9 @@ public class UserService {
         user.setActive(true);
         user.setRole(Role.USER);
         return this.repository.save(user);
+    }
+
+    public List<VUserExperienceLastMonth> getTopUserExperienceLastMonth(Integer limit) {
+        return this.vUserExperienceLastMonthService.findWithLimit(limit);
     }
 }

--- a/src/main/java/com/querodoar/querodoar_api/usuario/repository/VUserExperienceLastMonthService.java
+++ b/src/main/java/com/querodoar/querodoar_api/usuario/repository/VUserExperienceLastMonthService.java
@@ -1,0 +1,15 @@
+package com.querodoar.querodoar_api.usuario.repository;
+
+import com.querodoar.querodoar_api.usuario.view.VUserExperienceLastMonth;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface VUserExperienceLastMonthService extends JpaRepository<VUserExperienceLastMonth,Integer> {
+    @Query(value = "SELECT * FROM v_user_experience_last_month LIMIT :limit", nativeQuery = true)
+    List<VUserExperienceLastMonth> findWithLimit(@Param("limit") int limit);
+}

--- a/src/main/java/com/querodoar/querodoar_api/usuario/view/VUserExperienceLastMonth.java
+++ b/src/main/java/com/querodoar/querodoar_api/usuario/view/VUserExperienceLastMonth.java
@@ -1,0 +1,47 @@
+package com.querodoar.querodoar_api.usuario.view;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.Immutable;
+
+import java.math.BigDecimal;
+
+/**
+ * Mapping for DB view
+ */
+@Getter
+@Setter
+@Entity
+@Immutable
+@Table(name = "v_user_experience_last_month")
+public class VUserExperienceLastMonth {
+    @Id
+    @Column(name = "user_id")
+    private Integer userId;
+
+    @Size(max = 150)
+    @Column(name = "name", length = 150)
+    private String name;
+
+    @Size(max = 256)
+    @Column(name = "photo", length = 256)
+    private String photo;
+
+    @Column(name = "location", length = Integer.MAX_VALUE)
+    private String location;
+
+    @Column(name = "donation_month")
+    private Long donationMonth;
+
+    @Column(name = "exp_month")
+    private Long expMonth;
+
+    @Column(name = "level", precision = 4)
+    private BigDecimal level;
+
+}

--- a/src/main/resources/db/migration/V10__hall_of_fame.sql
+++ b/src/main/resources/db/migration/V10__hall_of_fame.sql
@@ -1,0 +1,102 @@
+/*
+==================================================================================
+Autor:          Kauê Gomes
+Data:           24/09/2025
+Projeto:        Quero Doar – Estrutura de logs de progressão e ranking de usuários
+Versão:         10.0
+Descrição:
+    Este roteiro cria a tabela leveling_log para registrar pontos de experiência
+    ganhos pelos usuários, cria índices para otimizar consultas, define uma view
+    (v_user_experience_last_month) para exibir o ranking de experiência e doações
+    do último mês, popula a tabela progression_guide com identificadores padrão
+    e ajusta permissões de acesso.
+
+Objetivo:
+    - Registrar de forma estruturada os pontos de experiência (XP) ganhos pelos
+      usuários em diferentes contextos, vinculados a guias de progressão.
+    - Disponibilizar uma visão consolidada (hall da fama) que mostra os usuários
+      com maior experiência e doações concluídas no último mês.
+    - Garantir consistência e segurança no uso da tabela progression_guide,
+      restringindo alterações diretas e permitindo apenas consultas públicas.
+
+Observações:
+    - Compatível com PostgreSQL.
+    - Inclui criação de tabela, índices, view e inserções iniciais.
+    - A tabela leveling_log referencia as tabelas leveling e progression_guide.
+    - A view v_user_experience_last_month agrega dados de usuários, doações,
+      localização e experiência.
+    - progression_guide é populada com identificadores básicos de progressão
+      (doação concluída e pedido de doação concluído).
+    - Permissões ajustadas: apenas SELECT público em progression_guide.
+==================================================================================
+*/
+
+BEGIN;
+    -- Criação da tabela leveling_log
+    CREATE TABLE public.leveling_log
+    (
+        leveling_log_id serial NOT NULL,
+        user_id integer NOT NULL,
+        progression_guide_id integer NOT NULL,
+        exp_points integer NOT NULL,
+        date timestamp with time zone NOT NULL,
+        campaign_id integer,
+        PRIMARY KEY (leveling_log_id),
+        FOREIGN KEY (user_id)
+            REFERENCES public.leveling (user_id) MATCH SIMPLE
+            ON UPDATE CASCADE
+            ON DELETE CASCADE
+            NOT VALID,
+        FOREIGN KEY (progression_guide_id)
+            REFERENCES public.progression_guide (progression_guide_id) MATCH SIMPLE
+            ON UPDATE CASCADE
+            ON DELETE CASCADE
+            NOT VALID
+    );
+
+    ALTER TABLE IF EXISTS public.leveling_log
+        OWNER to quero_doar;
+
+    -- Criação dos índices da tabela leveling_log
+    CREATE INDEX idx_date ON leveling_log (date);
+    CREATE INDEX idx_user ON leveling_log (user_id);
+
+    -- Criação da view para o hall da fama
+    CREATE OR REPLACE VIEW public.v_user_experience_last_month AS
+    SELECT
+        u.user_id,
+        u.name,
+        u.photo,
+        (city.name || ' (' || s.acronym || ')') AS location,
+        COUNT(d.donation_id) AS donation_month,
+        COALESCE(SUM(ll.exp_points), 0) AS exp_month
+    FROM
+        "user" AS u
+            LEFT JOIN
+        leveling_log AS ll ON u.user_id = ll.user_id
+            AND ll.date >= date_trunc('month', now()) - interval '1 month'
+            AND ll.date <  date_trunc('month', now())
+            LEFT JOIN
+        donation AS d ON u.user_id = d.creator_user_id AND d.status = 'F'
+            LEFT JOIN
+        address AS a ON u.address_id = a.address_id
+            LEFT JOIN
+        city ON a.city_id = city.city_id
+            LEFT JOIN
+        state AS s ON city.state_id = s.state_id
+    GROUP BY
+        u.user_id, city.name, s.acronym
+    ORDER BY
+        exp_month DESC,
+        donation_month DESC,
+        name ASC;
+
+    -- Popula progression_guide
+    INSERT INTO public.progression_guide (identifier, description, exp_points) VALUES
+       ('DONATION', 'Doação concluída', 50),
+       ('DONATION_REQUEST', 'Pedido de doação concluído', 30);
+
+    -- Bloqueia tabela de referencia
+    REVOKE INSERT, UPDATE, DELETE ON progression_guide FROM public; --tabela referencia
+    GRANT SELECT ON progression_guide TO public;
+END;

--- a/src/main/resources/db/migration/V11__add_level_v_hall_of_fame.sql
+++ b/src/main/resources/db/migration/V11__add_level_v_hall_of_fame.sql
@@ -1,0 +1,36 @@
+/*
+==================================================================================
+Autor:          Kauê Gomes
+Data:           24/09/2025
+Projeto:        Quero Doar – Adiciona a informação de nível à view do hall da fama
+Versão:         11.0
+Descrição:
+    Este roteiro adiciona a coluna v_user_experience_last_month.level e adiciona
+    índice composto entre as colunas donation.creator_user_id e donation.status
+    para melhorar a performance da consulta da view.
+==================================================================================
+*/
+
+BEGIN;
+    CREATE OR REPLACE VIEW public.v_user_experience_last_month
+    AS
+    SELECT u.user_id,
+           u.name,
+           u.photo,
+           ((city.name::text || ' ('::text) || s.acronym::text) || ')'::text AS location,
+           count(d.donation_id) AS donation_month,
+           COALESCE(sum(ll.exp_points), 0::bigint) AS exp_month,
+           level.level
+    FROM "user" u
+             INNER JOIN leveling ON u.user_id = leveling.user_id
+             INNER JOIN level ON leveling.level_id = level.level
+             LEFT JOIN leveling_log ll ON u.user_id = ll.user_id AND ll.date >= (date_trunc('month'::text, now()) - '1 mon'::interval) AND ll.date < date_trunc('month'::text, now())
+             LEFT JOIN donation d ON u.user_id = d.creator_user_id AND d.status = 'F'::"char"
+             LEFT JOIN address a ON u.address_id = a.address_id
+             LEFT JOIN city ON a.city_id = city.city_id
+             LEFT JOIN state s ON city.state_id = s.state_id
+    GROUP BY u.user_id, city.name, s.acronym, level.level
+    ORDER BY (COALESCE(sum(ll.exp_points), 0::bigint)) DESC, (count(d.donation_id)) DESC, u.name;
+
+    CREATE INDEX idx_creator_user_status ON public.donation (creator_user_id, status);
+END;


### PR DESCRIPTION
This pull request introduces a new "Hall of Fame" feature that highlights top users based on their experience and donations in the last month. It includes backend changes for database support, a new API endpoint for public access, and supporting service and view classes. The main themes are public API expansion and database/view enhancements for user ranking.

**Public API Expansion**
* Added a new public endpoint `GET /api/user/public/hall-of-fame/{top}` in `UserController` to retrieve the top users by experience last month, with validation for the `top` parameter.
* Updated security configuration to allow anonymous access to the new hall of fame endpoint under `/api/user/public/**`.

**Database and View Enhancements**
* Added migration scripts (`V10__hall_of_fame.sql` and `V11__add_level_v_hall_of_fame.sql`) to create the `leveling_log` table, indexes, and the `v_user_experience_last_month` view, including the new `level` column and query optimizations. [[1]](diffhunk://#diff-a3bbd143b5ae21ac94702b923ecae52401e48b47584dd033c64454823276d2ecR1-R102) [[2]](diffhunk://#diff-1f1a349dde39690242707af857e13b18286e36629296e3acdcdc369996b5e445R1-R36)
* Introduced the `VUserExperienceLastMonth` entity to map the database view for user ranking and experience.
* Created the `VUserExperienceLastMonthService` repository for querying the hall of fame view with a limit.

**Service Layer Support**
* Added service logic in `UserService` to fetch the top users from the hall of fame view via the new repository. [[1]](diffhunk://#diff-5b5dec8cadccc19fdf8a599882c71478d99aa24383947b604079dd629cee34b2R48-R50) [[2]](diffhunk://#diff-5b5dec8cadccc19fdf8a599882c71478d99aa24383947b604079dd629cee34b2R250-R253)… view com informações de nível